### PR TITLE
Fix: Removed headers from authorization request

### DIFF
--- a/annotations/security-schemes/oauth-2-custom-settings.raml
+++ b/annotations/security-schemes/oauth-2-custom-settings.raml
@@ -44,10 +44,6 @@ description: |
                 required: true
                 description: |
                   A resource ID that defines a domain of authorization.
-            headers:
-              x-auth-resource:
-                type: string
-                required: false
           accessTokenSettings:
             body:
               resource:
@@ -55,6 +51,15 @@ description: |
                 required: true
                 description: |
                   A resource ID that defines a domain of authorization.
+            headers:
+              x-auth-resource:
+                type: string
+                required: false
+            queryParameters:
+              tokenResource:
+                type: string
+                displayName: Token resource
+                required: true
         accessTokenUri: https://auth.domain.com/authorize
         authorizationUri: https://auth.domain.com/token
         authorizationGrants: [implicit]
@@ -84,17 +89,6 @@ properties:
 
           If you define a parameter that is already defined in OAuth 2.0 specification
           (RFC6749) it should be ignored by the processor.
-        type: object
-        required: false
-        properties:
-          /a-zA-Z0-9\-\_/*:
-            type: object
-            required: false
-      headers:
-        displayName: Authorization headers
-        description: |
-          Headers to be set on the authorization request.
-          Use the same notation as RAML's `headers`.
         type: object
         required: false
         properties:


### PR DESCRIPTION
 It is impossible to apply headers to authorization request since it can only a window opening an URL.