### PR TITLE
Method tags (WIP)

### DIFF
--- a/annotations/methods/README.md
+++ b/annotations/methods/README.md
@@ -1,0 +1,24 @@
+# Method annotations
+
+## `tags`
+
+### Purpose
+
+> This annotation is an equivalent of the `tags` property of the OpenAPI OAS 3.0 Specification. Note
+  that it works slighly differently than its OAS counterpart. It has been simplified and tags are
+  defined and accessed globally whether at the root of the document or on a method. 
+
+(see full [description](tags.raml))
+
+### What's included?
+
+This directory contains the following RAML fragments:
+- tags.raml (AnnotationTypeDeclaration)
+- tags-lib.raml (Library)
+
+and the following example:
+- tags-example.raml
+
+### Which tools support this
+
+- [mulesoft/api-console (v5.0.x)](https://github.com/mulesoft/api-console)

--- a/annotations/methods/tags-example.raml
+++ b/annotations/methods/tags-example.raml
@@ -1,0 +1,24 @@
+#%RAML 1.0
+title: API with tags
+
+annotationTypes:
+  tags: !include tags.raml
+
+(tags):
+  - name: users
+    description: This tag denotes a "User"-related method
+
+/users:
+  get:
+    (tags): [users]
+
+  /{id}:
+    get:
+      (tags): [users]
+
+  /me:
+    get:
+      (tags):
+        - users
+        - name: alias
+          description: This is an alias

--- a/annotations/methods/tags-lib.raml
+++ b/annotations/methods/tags-lib.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0 Library
+
+types:
+  tagObject:
+    properties: 
+      name: string
+      description?: string

--- a/annotations/methods/tags.raml
+++ b/annotations/methods/tags.raml
@@ -1,0 +1,59 @@
+#%RAML 1.0 AnnotationTypeDeclaration
+
+uses:
+  lib: tags-lib.raml
+
+displayName: Tags Object
+description: |
+  This annotation is an equivalent of the `tags` property of the OpenAPI OAS 3.0 Specification. Note
+  that it works slighly differently than its OAS counterpart. It has been simplified and tags are
+  defined and accessed globally whether at the root of the document or on a method.
+
+  It can either be an array of references to an existing tag, e.g.
+
+  ```yaml
+  #%RAML 1.0
+  title: my example API
+
+  annotationTypes:
+    tags: !include tags.raml
+
+  (tags):
+    - name: bar
+      description: This is a "bar" tagged resource
+
+  /foo:
+    get:
+      (tags): 
+        - bar
+        - qux:
+            name: qux
+            description: This is a "qux" tagged resource
+
+  /users:
+    post:
+      (tags): [bar, qux]
+  ```
+
+  or an inline tag definition that can later be referenced:
+
+  ```yaml
+  #%RAML 1.0
+  title: my example API
+
+  annotationTypes:
+    tags: !include tags.raml
+
+  /foo:
+    get:
+      (tags):
+        - name: bar
+          description: This is a "bar" tagged resource
+
+  /users:
+    post:
+      (tags): [bar]
+  ```
+type: array
+items: string | lib.tagObject
+allowedTargets: [API, Method]


### PR DESCRIPTION
This is a first attempt at providing a `tags` annotation similar to the OAS 3.0 tagging feature.

See OAS 3.0 related sections:
 - [Tag Object](http://spec.openapis.org/oas/v3.0.0.html#tag-object)
 - [Root-level fixed fields](http://spec.openapis.org/oas/v3.0.0.html#fixed-fields)

CC: @jarrodek 